### PR TITLE
remove THC.h

### DIFF
--- a/csrc/common.hpp
+++ b/csrc/common.hpp
@@ -99,3 +99,21 @@ scalar_t Abs(scalar_t x) {
 
 }
 
+
+/**
+   Computes ceil(a / b)
+*/
+template <typename T>
+__host__ __device__ __forceinline__ T THCCeilDiv(T a, T b) {
+  return (a + b - 1) / b;
+}
+
+/**
+   Computes ceil(a / b) * b; i.e., rounds up `a` to the next highest
+   multiple of b
+*/
+template <typename T>
+__host__ __device__ __forceinline__ T THCRoundUp(T a, T b) {
+  return THCCeilDiv(a, b) * b;
+}
+

--- a/csrc/focal_kernel.cu
+++ b/csrc/focal_kernel.cu
@@ -111,7 +111,7 @@ at::Tensor FocalLoss_forward_cuda(const at::Tensor &logits,
     ));
     dim3 block(512);
     if (losses.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return losses;
     }
 
@@ -125,7 +125,7 @@ at::Tensor FocalLoss_forward_cuda(const at::Tensor &logits,
             scalar_t(gamma), scalar_t(alpha)
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return losses;
 }
 
@@ -147,7 +147,7 @@ at::Tensor FocalLoss_backward_cuda(const at::Tensor &grad,
     ));
     dim3 block(512);
     if (grad_logits.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_logits;
     }
 
@@ -162,7 +162,7 @@ at::Tensor FocalLoss_backward_cuda(const at::Tensor &grad,
             scalar_t(gamma), scalar_t(alpha)
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/focal_kernel.cu
+++ b/csrc/focal_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/focal_kernel_old.cu
+++ b/csrc/focal_kernel_old.cu
@@ -95,7 +95,7 @@ at::Tensor FocalLoss_forward_cuda(const at::Tensor &logits,
     ));
     dim3 block(512);
     if (losses.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return losses;
     }
 
@@ -109,7 +109,7 @@ at::Tensor FocalLoss_forward_cuda(const at::Tensor &logits,
             scalar_t(gamma), scalar_t(alpha)
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return losses;
 }
 
@@ -131,7 +131,7 @@ at::Tensor FocalLoss_backward_cuda(const at::Tensor &grad,
     ));
     dim3 block(512);
     if (grad_logits.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_logits;
     }
 
@@ -146,7 +146,7 @@ at::Tensor FocalLoss_backward_cuda(const at::Tensor &grad,
             scalar_t(gamma), scalar_t(alpha)
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/focal_kernel_old.cu
+++ b/csrc/focal_kernel_old.cu
@@ -3,7 +3,6 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/large_margin_kernel.cu
+++ b/csrc/large_margin_kernel.cu
@@ -12,6 +12,7 @@
 #include <cfloat>
 
 #include <iostream>
+#include "common.hpp"
 
 using std::cout;
 using std::endl;

--- a/csrc/large_margin_kernel.cu
+++ b/csrc/large_margin_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/large_margin_kernel.cu
+++ b/csrc/large_margin_kernel.cu
@@ -411,7 +411,7 @@ at::Tensor large_margin_forward_cuda(const at::Tensor &logits,
     // allocate memory and cuda grid/block
     auto losses = torch::empty_like(labels, logits.options());
     if (losses.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return losses;
     }
 
@@ -452,7 +452,7 @@ at::Tensor large_margin_forward_cuda(const at::Tensor &logits,
         });
     }
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return losses;
 }
 
@@ -473,7 +473,7 @@ at::Tensor large_margin_backward_cuda(const at::Tensor &logits,
     // allocate memory and cuda grid/block
     auto grad_logits = torch::empty_like(logits);
     if (grad_logits.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_logits;
     }
 
@@ -513,7 +513,7 @@ at::Tensor large_margin_backward_cuda(const at::Tensor &logits,
             );
         });
     }
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/layer_norm.cu
+++ b/csrc/layer_norm.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/layer_norm.cu
+++ b/csrc/layer_norm.cu
@@ -307,7 +307,7 @@ at::Tensor LayerNorm_forward_cuda(const at::Tensor &x,
         });
     }
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return res;
 }
 
@@ -363,7 +363,7 @@ at::Tensor LayerNorm_backward_cuda(const at::Tensor &grad,
         });
     }
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return res;
 }
 

--- a/csrc/lovasz_softmax.cu
+++ b/csrc/lovasz_softmax.cu
@@ -671,7 +671,7 @@ std::tuple<at::Tensor, at::Tensor> Lovasz_softmax_forward_cuda(const at::Tensor 
     auto jacc = at::empty_like(logits).reshape({dimsize, -1});
     auto loss = at::empty({dimsize}, logits.options());
     if (errs.numel() == 0 | jacc.numel() == 0 | loss.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return std::make_tuple(errs, jacc);
     }
 
@@ -685,7 +685,7 @@ std::tuple<at::Tensor, at::Tensor> Lovasz_softmax_forward_cuda(const at::Tensor 
     // reduce sum operation
     LovaszComputeLoss(errs, jacc, loss);
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return std::make_tuple(loss, jacc);
 }
 
@@ -768,7 +768,7 @@ at::Tensor Lovasz_softmax_backward_cuda(const at::Tensor &grad, const at::Tensor
         });
     }
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/lovasz_softmax.cu
+++ b/csrc/lovasz_softmax.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/lovasz_softmax_old.cu
+++ b/csrc/lovasz_softmax_old.cu
@@ -562,7 +562,7 @@ std::tuple<at::Tensor, at::Tensor> Lovasz_softmax_forward_cuda(const at::Tensor 
     auto errs = at::empty_like(logits).reshape({dimsize, -1});
     auto jacc = at::zeros_like(logits).reshape({dimsize, -1});
     if (errs.numel() == 0 | jacc.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return std::make_tuple(errs, jacc);
     }
 
@@ -585,7 +585,7 @@ std::tuple<at::Tensor, at::Tensor> Lovasz_softmax_forward_cuda(const at::Tensor 
     // TODO: define the loss tensor outsize, and pass it as an arg of the function
     auto loss = LovaszComputeLoss(errs, jacc);
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return std::make_tuple(loss, jacc);
 }
 
@@ -648,7 +648,7 @@ at::Tensor Lovasz_softmax_backward_cuda(const at::Tensor &grad, const at::Tensor
     });
 
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/lovasz_softmax_old.cu
+++ b/csrc/lovasz_softmax_old.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/lsr_kernel.cu
+++ b/csrc/lsr_kernel.cu
@@ -204,7 +204,7 @@ at::Tensor LSR_forward_cuda(const at::Tensor &logits,
     auto losses = torch::zeros_like(labels, logits.options());
     auto log_scores = torch::log_softmax(logits, 1);
     if (losses.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return losses;
     }
 
@@ -247,7 +247,7 @@ at::Tensor LSR_forward_cuda(const at::Tensor &logits,
         });
     }
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return losses;
 }
 
@@ -268,7 +268,7 @@ at::Tensor LSR_backward_cuda(const at::Tensor &logits,
     // allocate memory and cuda grid/block
     auto grad_logits = torch::softmax(logits, 1);
     if (grad_logits.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_logits;
     }
 
@@ -287,7 +287,7 @@ at::Tensor LSR_backward_cuda(const at::Tensor &logits,
             ignore_index, smooth
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/lsr_kernel.cu
+++ b/csrc/lsr_kernel.cu
@@ -12,6 +12,7 @@
 #include <cfloat>
 
 #include <iostream>
+#include "common.hpp"
 
 using std::cout;
 using std::endl;

--- a/csrc/lsr_kernel.cu
+++ b/csrc/lsr_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/mish_kernel.cu
+++ b/csrc/mish_kernel.cu
@@ -67,7 +67,7 @@ at::Tensor Mish_forward_cuda(const at::Tensor &feat) {
     ));
     dim3 block(512);
     if (activations.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return activations;
     }
 
@@ -79,7 +79,7 @@ at::Tensor Mish_forward_cuda(const at::Tensor &feat) {
             activations.contiguous().data_ptr<scalar_t>()
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return activations;
 }
 
@@ -97,7 +97,7 @@ at::Tensor Mish_backward_cuda(const at::Tensor &grad, const at::Tensor &feat) {
     ));
     dim3 block(512);
     if (grad_feat.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_feat;
     }
 
@@ -110,7 +110,7 @@ at::Tensor Mish_backward_cuda(const at::Tensor &grad, const at::Tensor &feat) {
             grad_feat.contiguous().data_ptr<scalar_t>()
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_feat;
 }
 

--- a/csrc/mish_kernel.cu
+++ b/csrc/mish_kernel.cu
@@ -10,6 +10,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cfloat>
+#include "common.hpp"
 
 
 #define EXP_THRESH 20.

--- a/csrc/mish_kernel.cu
+++ b/csrc/mish_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/ohem_label_kernel.cu
+++ b/csrc/ohem_label_kernel.cu
@@ -14,6 +14,7 @@
 #include <cfloat>
 
 #include <iostream>
+#include "common.hpp"
 
 using std::cout;
 using std::endl;

--- a/csrc/ohem_label_kernel.cu
+++ b/csrc/ohem_label_kernel.cu
@@ -188,7 +188,7 @@ at::Tensor Score_ohem_label_cuda(const at::Tensor &logits,
     auto scores = torch::empty_like(labels, logits.options());
     thrust::device_vector<int> idx(samplesize);
     if (ohem_label.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return ohem_label;
     }
 
@@ -257,7 +257,7 @@ at::Tensor Score_ohem_label_cuda(const at::Tensor &logits,
             ignore_index, score_thresh, n_min
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return ohem_label;
 }
 

--- a/csrc/ohem_label_kernel.cu
+++ b/csrc/ohem_label_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/one_hot_kernel.cu
+++ b/csrc/one_hot_kernel.cu
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <vector>
+#include "common.hpp"
 
 using std::cout;
 using std::endl;

--- a/csrc/one_hot_kernel.cu
+++ b/csrc/one_hot_kernel.cu
@@ -329,7 +329,7 @@ at::Tensor Label_one_hot_cuda(const at::Tensor &labels,
         );
     }
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return one_hot;
 }
 

--- a/csrc/one_hot_kernel.cu
+++ b/csrc/one_hot_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/soft_dice_kernel.cu
+++ b/csrc/soft_dice_kernel.cu
@@ -154,7 +154,7 @@ at::Tensor SoftDice_forward_cuda(const at::Tensor &logits,
     dim3 grid2(1);
     dim3 block2(BLOCKSIZE);
     if (losses.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return losses;
     }
 
@@ -176,7 +176,7 @@ at::Tensor SoftDice_forward_cuda(const at::Tensor &logits,
             denor.contiguous().data<scalar_t>()
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return losses;
 }
 
@@ -204,7 +204,7 @@ at::Tensor SoftDice_backward_cuda(const at::Tensor &grad,
     ), batchsize);
     dim3 block(BLOCKSIZE);
     if (grad_logits.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_logits;
     }
 
@@ -230,7 +230,7 @@ at::Tensor SoftDice_backward_cuda(const at::Tensor &grad,
             p, smooth
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/soft_dice_kernel.cu
+++ b/csrc/soft_dice_kernel.cu
@@ -12,6 +12,7 @@
 #include <cfloat>
 
 #include <iostream>
+#include "common.hpp"
 
 using std::cout;
 using std::endl;

--- a/csrc/soft_dice_kernel.cu
+++ b/csrc/soft_dice_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/soft_dice_kernel_v2.cu
+++ b/csrc/soft_dice_kernel_v2.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/soft_dice_kernel_v2.cu
+++ b/csrc/soft_dice_kernel_v2.cu
@@ -300,7 +300,7 @@ at::Tensor SoftDice_forward_cuda(const at::Tensor &logits,
             {batchsize * n_blockxs_sample}, 
             logits.options());
     if (losses.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return losses;
     }
     // call kernel
@@ -324,7 +324,7 @@ at::Tensor SoftDice_forward_cuda(const at::Tensor &logits,
             smooth
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return losses;
 }
 
@@ -403,7 +403,7 @@ at::Tensor SoftDice_backward_cuda(const at::Tensor &grad,
             p
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_logits;
 }
 

--- a/csrc/swish_kernel.cu
+++ b/csrc/swish_kernel.cu
@@ -109,7 +109,7 @@ at::Tensor Swish_forward_cuda(const at::Tensor &feat) {
     ));
     dim3 block(BLOCKSIZE);
     if (activations.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return activations;
     }
 
@@ -121,7 +121,7 @@ at::Tensor Swish_forward_cuda(const at::Tensor &feat) {
             activations.contiguous().data_ptr<scalar_t>()
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return activations;
 }
 
@@ -141,7 +141,7 @@ at::Tensor Swish_backward_cuda(const at::Tensor &grad, const at::Tensor &feat) {
     ));
     dim3 block(BLOCKSIZE);
     if (grad_feat.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_feat;
     }
 
@@ -154,7 +154,7 @@ at::Tensor Swish_backward_cuda(const at::Tensor &grad, const at::Tensor &feat) {
             grad_feat.contiguous().data_ptr<scalar_t>()
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_feat;
 }
 
@@ -172,7 +172,7 @@ at::Tensor HSwish_forward_cuda(const at::Tensor &feat) {
     ));
     dim3 block(BLOCKSIZE);
     if (activations.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return activations;
     }
 
@@ -184,7 +184,7 @@ at::Tensor HSwish_forward_cuda(const at::Tensor &feat) {
             activations.contiguous().data_ptr<scalar_t>()
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return activations;
 }
 
@@ -203,7 +203,7 @@ at::Tensor HSwish_backward_cuda(const at::Tensor &grad, const at::Tensor &feat) 
     ));
     dim3 block(BLOCKSIZE);
     if (grad_feat.numel() == 0) {
-        THCudaCheck(cudaGetLastError());
+        AT_CUDA_CHECK(cudaGetLastError());
         return grad_feat;
     }
 
@@ -216,7 +216,7 @@ at::Tensor HSwish_backward_cuda(const at::Tensor &grad, const at::Tensor &feat) 
             grad_feat.contiguous().data_ptr<scalar_t>()
         );
     });
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_feat;
 }
 

--- a/csrc/swish_kernel.cu
+++ b/csrc/swish_kernel.cu
@@ -11,6 +11,7 @@
 #include <cuda_runtime.h>
 #include <cfloat>
 
+#include "common.hpp"
 
 #define BLOCKSIZE 512
 

--- a/csrc/swish_kernel.cu
+++ b/csrc/swish_kernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 

--- a/csrc/taylor_softmax.cu
+++ b/csrc/taylor_softmax.cu
@@ -387,7 +387,7 @@ at::Tensor TaylorSoftmax_backward_cuda(const at::Tensor &grad,
         });
     }
 
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_feat;
 }
 

--- a/csrc/taylor_softmax.cu
+++ b/csrc/taylor_softmax.cu
@@ -3,7 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 


### PR DESCRIPTION
Latest pytorch (1.11) has removed THC.h, with that gone the following changes were also made so it can be compiled:
1. `THCudaCheck` -> `AT_CUDA_CHECK`
2. `THCCeilDiv` was reintroduced into `common.hpp`
3.  `common.hpp` were added to all cuda source files.